### PR TITLE
fix(tui): READMEパネルのビューポート高さ計算を修正する

### DIFF
--- a/tui/keys.go
+++ b/tui/keys.go
@@ -33,6 +33,7 @@ func (m Model) handleSearchPaneKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "?":
 		if !m.search.focused {
 			m.showHelp = !m.showHelp
+			m.readme.vp.Height = m.rightPanelContentH()
 			return m, nil
 		}
 
@@ -146,6 +147,7 @@ func (m Model) handleNormalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "?":
 		m.showHelp = !m.showHelp
+		m.readme.vp.Height = m.rightPanelContentH()
 		return m, nil
 
 	case "q", "ctrl+c":

--- a/tui/model.go
+++ b/tui/model.go
@@ -97,6 +97,11 @@ func (m Model) mainH() int {
 	return m.height - m.footerH()
 }
 
+// rightPanelContentH returns the content height for the right README panel.
+func (m Model) rightPanelContentH() int {
+	return m.mainH() - 2
+}
+
 // searchListH returns the number of visible result rows in the [2] pane.
 func (m Model) searchListH() int {
 	mainH := m.mainH()

--- a/tui/update.go
+++ b/tui/update.go
@@ -23,7 +23,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				newRightW = 1
 			}
 			m.readme.vp.Width = newRightW
-			m.readme.vp.Height = m.height - 2
+			m.readme.vp.Height = m.rightPanelContentH()
 			if m.readme.raw != "" {
 				lines := renderMarkdown(m.readme.raw, newRightW)
 				m.readme.lines = lines
@@ -53,7 +53,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if rightW < 1 {
 			rightW = 1
 		}
-		m.readme.vp = viewport.New(rightW, m.height-2)
+		m.readme.vp = viewport.New(rightW, m.rightPanelContentH())
 		m, autoCmd := m.withAutoLoadReadme()
 		if autoCmd == nil {
 			m.readme.vp.SetContent("← Select a repository and press Enter to load README")

--- a/tui/view.go
+++ b/tui/view.go
@@ -262,7 +262,11 @@ func renderRight(m Model, width, height int) string {
 		height--
 	}
 	if len(m.readme.lines) == 0 {
-		lines = append(lines, m.readme.vp.View())
+		vpLines := strings.Split(m.readme.vp.View(), "\n")
+		if len(vpLines) > height {
+			vpLines = vpLines[:height]
+		}
+		lines = append(lines, strings.Join(vpLines, "\n"))
 		return strings.Join(lines, "\n")
 	}
 	cursorStyle := styleMainCursor.Width(width)


### PR DESCRIPTION
## 概要

- `rightPanelContentH()` ヘルパーを追加し、フッター高さを考慮した正しいビューポート高さ計算に統一
- ヘルプ表示トグル時（`?` キー）にもビューポート高さを更新するよう修正
- ビューポートのコンテンツが描画領域をはみ出さないよう行数をクリップ

## 動作確認

```bash
go run . 
# ? キーでヘルプ表示を切り替えてREADMEパネルの高さが正しく調整されることを確認
```